### PR TITLE
Add possiblity to define how many tests will be running concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,16 @@ The principles of parsing are:
  * E.g., if both the suite and the suite member contain the `@RunSequentially`
    annotation, honor the annotation of the suite member
 
+
+## Controlling amount of concurrently running tests
+
+By default, Havarunner will use Runtime.getRuntime.availableProcessors() to control how many tests are executed concurrently.
+
+As that can introduce problems in environments running multiple Havarunner jobs at same time, you can
+override the maximum number of parallel tests with the system property havarunner.maximum_parallelism.
+
+For example, havarunner.maximum_parallelism=8 will instruct HavaRunner to use at most 8 threads.
+
 ## Supported JUnit annotations
 
 HavaRunner supports only a limited set of JUnit annotations. Here they are:

--- a/src/main/scala/com/github/havarunner/ConcurrencyControl.scala
+++ b/src/main/scala/com/github/havarunner/ConcurrencyControl.scala
@@ -6,7 +6,12 @@ import RunSequentially.SequentialityContext._
 import scala.collection.mutable
 
 private[havarunner] object ConcurrencyControl {
-  val forParallelTests = new Semaphore(Runtime.getRuntime.availableProcessors(), true)
+  val forParallelTests = new Semaphore(permits, true)
+
+  def permits: Int = {
+    System.getProperty("havarunner.parallel.concurrency", Runtime.getRuntime.availableProcessors().toString).toInt
+  }
+
   val forTestsMarkedByTheDefaultContext = new Semaphore(1)
   val forTestsOfSameInstance = new mutable.HashMap[Any, Semaphore] with mutable.SynchronizedMap[Any, Semaphore]
 

--- a/src/main/scala/com/github/havarunner/ConcurrencyControl.scala
+++ b/src/main/scala/com/github/havarunner/ConcurrencyControl.scala
@@ -9,7 +9,7 @@ private[havarunner] object ConcurrencyControl {
   val forParallelTests = new Semaphore(permits, true)
 
   def permits: Int = {
-    System.getProperty("havarunner.parallel.concurrency", Runtime.getRuntime.availableProcessors().toString).toInt
+    System.getProperty("havarunner.maximum_parallelism", Runtime.getRuntime.availableProcessors().toString).toInt
   }
 
   val forTestsMarkedByTheDefaultContext = new Semaphore(1)

--- a/src/test/java/com/github/havarunner/ConcurrencyControlTest.java
+++ b/src/test/java/com/github/havarunner/ConcurrencyControlTest.java
@@ -1,0 +1,24 @@
+package com.github.havarunner;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConcurrencyControlTest {
+
+    @Test
+    public void defaultsToAvailableProcessors() {
+        assertEquals(Runtime.getRuntime().availableProcessors(), ConcurrencyControl.permits());
+    }
+
+    @Test
+    public void defaultCanbeOverridenBySystemProperty() {
+        try {
+            System.setProperty("havarunner.parallel.concurrency", "99999");
+            assertEquals(99999, ConcurrencyControl.permits());
+        } finally {
+            System.clearProperty("havarunner.parallel.concurrency");
+        }
+    }
+
+}

--- a/src/test/java/com/github/havarunner/ConcurrencyControlTest.java
+++ b/src/test/java/com/github/havarunner/ConcurrencyControlTest.java
@@ -14,10 +14,10 @@ public class ConcurrencyControlTest {
     @Test
     public void defaultCanbeOverridenBySystemProperty() {
         try {
-            System.setProperty("havarunner.parallel.concurrency", "99999");
+            System.setProperty("havarunner.maximum_parallelism", "99999");
             assertEquals(99999, ConcurrencyControl.permits());
         } finally {
-            System.clearProperty("havarunner.parallel.concurrency");
+            System.clearProperty("havarunner.maximum_parallelism");
         }
     }
 


### PR DESCRIPTION
Although Runtime.getRuntime.availableProcessors() works fine in most cases,
it does not scale that well when one CI server is running tens of quite heavy jobs
using Havarunner.

So introduce system property "havarunner.parallel.concurrency" for overriding default Runtime.getRuntime.availableProcessors() for parallel tests.

We plan to use it to limit how many concurrent tests one job can run, hopefully speeding CI up for all users.